### PR TITLE
Add support for launching Ammonite REPL from sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target/
 local.sbt
 secret/
+.metals/
+.bloop/
+metals.sbt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sbt-ammonite-classpath
 
-**sbt-ammonite-classpath** is an sbt plug-in to export classpath of an sbt project to Ammonite Script, which can be then used in [Ammonite](https://ammonite.io/) or [Almond](http://almond.sh/).
+**sbt-ammonite-classpath** is an sbt plug-in to export classpath of an sbt project to Ammonite Script, which can be then used in [Ammonite](https://ammonite.io/) or [Almond](http://almond.sh/). Also supports running Ammonite REPL directly with desired classpath.
 
 ## Usage
 
@@ -17,6 +17,8 @@ object MyObject {
   def hello() = println("Hello, World!")
 }
 ```
+
+### Exporting Classpath for Almond or Ammonite
 
 ``` bash
 $ sbt Compile/fullClasspath/exportToAmmoniteScript && amm --predef target/scala-2.12/fullClasspath-Compile.sc
@@ -51,6 +53,69 @@ import $file.$
 @ mypackage.MyObject.hello() 
 Hello, World!
 ```
+
+### Launching Ammonite REPL
+
+This plugin also supports directly running Ammonite REPL from sbt. Similar to using above scopes you may launch the Ammonite REPL with desired classpath and compile scope as follows:
+
+``` bash
+sbt "{scope}:{classpath}::launchAmmoniteRepl"
+```
+
+Where **`scope`** can be one of `compile`, `test` and `runtime`, while **`classpath`** can be one of `fullClasspath`, `dependencyClasspath`, `managedClasspath`, `unmanagedClasspath`.
+
+Example:
+
+``` bash
+sbt "test:dependencyClasspath::launchAmmoniteRepl"
+```
+
+If you would like to run Ammonite REPL with full classpath, you can simply use `launchAmmoniteRepl` task within `compile` (or any other) scope without having to specify classpath task scope:
+
+``` bash
+sbt "compile:launchAmmoniteRepl" 
+# or simply (without scope, compile will be implied)
+sbt launchAmmoniteRepl
+```
+
+`initialCommands` setting is also supported. If your `initialCommands` or `launchAmmoniteRepl / initialCommands` setting is not appropriate for a given scope, you can override it in one of this plugin's scopes. For example if you would like to only have `import ammonite.ops._` in your Ammonite REPL but not Scala REPL, you can do as follows:
+``` scala
+...
+
+console / initialCommands := "println(\"Hello Console\")",
+
+Compile / launchAmmoniteRepl / initialCommands += "\nimport ammonite.ops._"
+
+// or simply launchAmmoniteRepl / initialCommands
+...
+```
+
+When you run `sbt launchAmmoniteRepl`, both commands will be in effect:
+
+``` bash
+sbt launchAmmoniteRepl
+...
+[info] running ammonite.Main --predef /private/tmp/example/target/scala-2.13/fullClasspath-Compile.sc --predef-code "println("Hello Console")
+[info] import ammonite.ops._"
+Loading...
+Hello Console
+Welcome to the Ammonite Repl 2.2.0-4-4bd225e (Scala 2.13.3 Java 1.8.0_252)
+@ ls! pwd 
+res2: LsSeq = 
+".bloop"          ".gitignore"      ".vscode"         "build.sbt"       'target
+".git"            ".metals"         'LICENCE          'project          'test
+".github"         ".scalafmt.conf"  "README.md"       'src
+
+@
+```
+
+By default it will use the `"latest.release"` version of Ammonite, but if you would like to change it, you can override `ammoniteVersion` setting, e.g.:
+
+``` scala
+ammoniteVersion := "2.1.4"
+Test / ammoniteVersion := "2.2.0"
+```
+
 ## Related work
 
 [sbt-ammonite](https://github.com/alexarchambault/sbt-ammonite) is an sbt 0.13 plug-in to launch Ammonite. It automatically passes the classpath instead of creating a `sc` file. However, it does not support Almond.

--- a/src/main/scala/com/thoughtworks/deeplearning/sbtammoniteclasspath/AmmoniteClasspath.scala
+++ b/src/main/scala/com/thoughtworks/deeplearning/sbtammoniteclasspath/AmmoniteClasspath.scala
@@ -16,37 +16,106 @@ object AmmoniteClasspath extends AutoPlugin {
   object autoImport {
     val exportToAmmoniteScript = taskKey[File](
       "Export classpath as a .sc file, which can be loaded by another ammonite script or an Almond notebook")
+
+    lazy val Ammonite = config("ammonite")
+      .extend(Compile)
+      .withDescription("Ammonite config to run REPL, similar to Compile (default) config.")
+    lazy val AmmoniteTest =
+      config("ammonite-test")
+      .extend(Test)
+      .withDescription("Ammonite config to run REPL, similar to Test config.")
+    lazy val AmmoniteRuntime = config("ammonite-runtime")
+      .extend(Runtime)
+      .withDescription("Ammonite config to run REPL, similar to Runtime config.")
+    
+    lazy val launchAmmoniteRepl = taskKey[Unit]("Run Ammonite REPL")
+
+    lazy val ammoniteVersion = settingKey[String]("Ammonite REPL Version")
   }
+
   import autoImport._
 
-  override def projectSettings: Seq[Def.Setting[_]] = Seq {
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+    ammoniteVersion := "latest.release"
+  )
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    classpathExportSettings ++
+      ammoniteRunSettings(Ammonite, Compile) ++
+      ammoniteRunSettings(AmmoniteTest, Test) ++
+      ammoniteRunSettings(AmmoniteRuntime, Runtime)
+
+  private val allClasspathKeys = Seq(fullClasspath, dependencyClasspath, managedClasspath, unmanagedClasspath)
+
+  def classpathExportSettings: Seq[Def.Setting[_]] = {
     val configuration = !Each(Seq(Compile, Test, Runtime))
-    val classpathKey = !Each(Seq(fullClasspath, dependencyClasspath, managedClasspath, unmanagedClasspath))
+    val classpathKey = !Each(allClasspathKeys)
 
-    exportToAmmoniteScript in classpathKey in configuration := {
-      val code = {
-        def ammonitePaths = List {
-          q"_root_.ammonite.ops.Path(${(!Each((classpathKey in configuration).value)).data.toString})"
-        }
-
-        def mkdirs = List {
-          val ammonitePath = !Each(ammonitePaths)
-          q"""
-          if (!_root_.ammonite.ops.exists($ammonitePath)) {
-            _root_.ammonite.ops.mkdir($ammonitePath)
+    Seq(
+      configuration / classpathKey  / exportToAmmoniteScript := {
+        val code = {
+          def ammonitePaths = List {
+            q"_root_.ammonite.ops.Path(${(!Each((configuration / classpathKey).value)).data.toString})"
           }
+
+          def mkdirs = List {
+            val ammonitePath = !Each(ammonitePaths)
+            q"""
+            if (!_root_.ammonite.ops.exists($ammonitePath)) {
+              _root_.ammonite.ops.mkdir($ammonitePath)
+            }
+            """
+          }
+
+          q"""
+          ..$mkdirs
+          interp.load.cp(Seq(..$ammonitePaths))
           """
         }
-
-        q"""
-        ..$mkdirs
-        interp.load.cp(Seq(..$ammonitePaths))
-        """
+        val file = (configuration / crossTarget).value / s"${classpathKey.key.label}-${configuration.id}.sc"
+        IO.write(file, code.syntax)
+        file
       }
-      val file = (crossTarget in configuration).value / s"${classpathKey.key.label}-${configuration.id}.sc"
-      IO.write(file, code.syntax)
-      file
-    }
-
+    )
   }
+
+  def ammoniteRunSettings(ammConf: Configuration, backingConf: Configuration): Seq[Def.Setting[_]] =
+    inConfig(ammConf)(
+      Defaults.compileSettings ++
+        Classpaths.ivyBaseSettings ++
+        Seq(
+          libraryDependencies     := Seq(("com.lihaoyi" %% "ammonite" % (ammConf / ammoniteVersion).value).cross(CrossVersion.full)),
+          connectInput            := true,
+          console                 := runTask(ammConf, backingConf, fullClasspath, ammConf / run / runner).value
+        ) ++
+        allClasspathKeys.map(classpathKey =>
+          classpathKey / console  := runTask(ammConf, backingConf, classpathKey, ammConf / run / runner).value
+        )
+    ) ++ Seq(
+      backingConf / launchAmmoniteRepl := (ammConf / console).value,
+      backingConf / launchAmmoniteRepl / initialCommands := (ammConf / console / initialCommands).value
+    ) ++ 
+      allClasspathKeys.map(classpathKey =>
+        backingConf / classpathKey / launchAmmoniteRepl := (ammConf / classpathKey / console).value
+      )
+
+  private def runTask(
+      ammConf: Configuration,
+      backingConf: Configuration,
+      classpath: TaskKey[Classpath],
+      scalaRun: Def.Initialize[Task[ScalaRun]],
+  ): Def.Initialize[Task[Unit]] = {
+    import Def.parserToInput
+    val parser = Def.spaceDelimited()
+    Def.task {
+      val mainClass = "ammonite.Main"
+      val args = Seq(
+        "--predef",       (backingConf / classpath / exportToAmmoniteScript).value.absolutePath,
+        "--predef-code",  (backingConf / launchAmmoniteRepl / initialCommands).value
+      )
+      val ammoniteOnlyClasspathFiles = sbt.Attributed.data((ammConf / managedClasspath).value)
+      scalaRun.value.run(mainClass, ammoniteOnlyClasspathFiles, args, streams.value.log).get
+    }
+  }
+
 }


### PR DESCRIPTION
The related `sbt-ammonite` repository doesn't seem like supporting sbt 1.0, so I thought I could add this feature to this plugin. Introduced a new task key `launchAmmoniteRepl`. It locks the System.out so that the sbt progress doesn't hinder with REPL's work (it causes flickering and takes up space). See: https://stackoverflow.com/a/29972867/294325.
