### PR TITLE
Bump scalameta version from 1.7.0 to 4.3.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ local.sbt
 secret/
 .metals/
 .bloop/
+.vscode/
 metals.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ scala:
 jdk:
   - openjdk8
 
+script:
+  sbt ++$TRAVIS_SCALA_VERSION test scripted
+
 before_cache:
   - find $HOME/.sbt -name '*.lock' -delete
   - find $HOME/.ivy2 -name 'ivydata-*.properties' -delete

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,14 @@
 sbtPlugin := true
 
+enablePlugins(SbtPlugin)
+
+scriptedBufferLog := false
+
+scriptedLaunchOpts := {
+  scriptedLaunchOpts.value ++
+    Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+}
+
 organization in ThisBuild := "com.thoughtworks.deeplearning"
 
 libraryDependencies += "com.thoughtworks.dsl" %% "keywords-each" % "1.5.3"
@@ -8,4 +17,4 @@ addCompilerPlugin("com.thoughtworks.dsl" %% "compilerplugins-bangnotation" % "1.
 
 addCompilerPlugin("com.thoughtworks.dsl" %% "compilerplugins-reseteverywhere" % "1.5.3")
 
-libraryDependencies += "org.scalameta" %% "scalameta" % "1.7.0"
+libraryDependencies += "org.scalameta" %% "scalameta" % "4.3.21"

--- a/src/main/scala/com/thoughtworks/deeplearning/sbtammoniteclasspath/AmmoniteClasspath.scala
+++ b/src/main/scala/com/thoughtworks/deeplearning/sbtammoniteclasspath/AmmoniteClasspath.scala
@@ -52,7 +52,7 @@ object AmmoniteClasspath extends AutoPlugin {
     val classpathKey = !Each(allClasspathKeys)
 
     Seq(
-      configuration / classpathKey  / exportToAmmoniteScript := {
+      configuration / classpathKey / exportToAmmoniteScript := {
         val code = {
           def ammonitePaths = List {
             q"_root_.ammonite.ops.Path(${(!Each((configuration / classpathKey).value)).data.toString})"
@@ -102,7 +102,7 @@ object AmmoniteClasspath extends AutoPlugin {
   private def runTask(
       ammConf: Configuration,
       backingConf: Configuration,
-      classpath: TaskKey[Classpath],
+      classpath: TaskKey[sbt.Keys.Classpath],
       scalaRun: Def.Initialize[Task[ScalaRun]],
   ): Def.Initialize[Task[Unit]] = {
     import Def.parserToInput

--- a/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/build.sbt
+++ b/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/build.sbt
@@ -1,0 +1,4 @@
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+  )

--- a/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/project/plugins.sbt
+++ b/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/project/plugins.sbt
@@ -1,0 +1,6 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.thoughtworks.deeplearning" % "sbt-ammonite-classpath" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.9.7")

--- a/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/src/main/scala/MainTest.scala
+++ b/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/src/main/scala/MainTest.scala
@@ -1,0 +1,5 @@
+object MainTest extends App {
+  def x: String = "5"
+  def y: Int = 6
+  println("hello")
+}

--- a/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/test
+++ b/src/sbt-test/sbt-ammonite-classpath/scalameta-version-conflict/test
@@ -1,0 +1,3 @@
+# check if classpath script file gets created
+> compile:fullClasspath::exportToAmmoniteScript
+$ exists target/scala-2.12/fullClasspath-Compile.sc


### PR DESCRIPTION
Incremented the version of dependent `scalameta` to 4.3.21 and resolved a name clash coming from `import scala.meta._` (`Classpath` => `sbt.Keys.Classpath`).

I also have a `scripted` test but it doesn't do much, just checks the existence of classpath script. So I didn't include it in this PR:
```
# check if classpath script file gets created
> compile:fullClasspath::exportToAmmoniteScript
$ exists target/scala-2.12/fullClasspath-Compile.sc
```