### PR TITLE
Update Ammonite to 2.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ res2: LsSeq =
 By default it will use the `"latest.release"` version of Ammonite, but if you would like to change it, you can override `ammoniteVersion` setting, e.g.:
 
 ``` scala
-ammoniteVersion := "2.1.4"
-Test / ammoniteVersion := "2.2.0"
+ammoniteVersion := "2.5.2"
+Test / ammoniteVersion := "2.5.2"
 ```
 
 ## Related work

--- a/src/main/scala/com/thoughtworks/deeplearning/sbtammoniteclasspath/AmmoniteClasspath.scala
+++ b/src/main/scala/com/thoughtworks/deeplearning/sbtammoniteclasspath/AmmoniteClasspath.scala
@@ -55,14 +55,14 @@ object AmmoniteClasspath extends AutoPlugin {
       configuration / classpathKey / exportToAmmoniteScript := {
         val code = {
           def ammonitePaths = List {
-            q"_root_.ammonite.ops.Path(${(!Each((configuration / classpathKey).value)).data.toString})"
+            q"_root_.os.Path(${(!Each((configuration / classpathKey).value)).data.toString})"
           }
 
           def mkdirs = List {
             val ammonitePath = !Each(ammonitePaths)
             q"""
-            if (!_root_.ammonite.ops.exists($ammonitePath)) {
-              _root_.ammonite.ops.mkdir($ammonitePath)
+            if (!_root_.os.exists($ammonitePath)) {
+              _root_.os.makeDir.all($ammonitePath)
             }
             """
           }


### PR DESCRIPTION
Ammonite dropped the support for the `ammonite.ops` package.
This migrates the macros to use `os.` instead.